### PR TITLE
Fix download path related issues

### DIFF
--- a/puush-installer/MainForm.cs
+++ b/puush-installer/MainForm.cs
@@ -41,7 +41,7 @@ namespace puush_installer
                 {
                     lblProgress.Text = "Beginning download...";
 
-                    string downloadPath = checker.Filename;
+                    string downloadPath = GetDownloadPath(checker.Filename);
                     FileStream fileStream = new FileStream(downloadPath, FileMode.Create, FileAccess.Write, FileShare.Read);
                     FileDownloader fileDownloader = new FileDownloader(checker.DownloadURL, fileStream, null, "application/octet-stream");
 
@@ -84,6 +84,25 @@ namespace puush_installer
             };
 
             bw.RunWorkerAsync();
+        }
+
+        private string GetDownloadPath(string filename)
+        {
+            string downloadFolder = "";
+
+            string tempFolder = Path.GetTempPath();
+
+            if (!string.IsNullOrEmpty(tempFolder))
+            {
+                downloadFolder = Path.Combine(tempFolder, "ShareX");
+
+                if (!Directory.Exists(downloadFolder))
+                {
+                    Directory.CreateDirectory(downloadFolder);
+                }
+            }
+
+            return Path.Combine(downloadFolder, filename);
         }
 
         private void ResetControls()


### PR DESCRIPTION
Currently Puush installer downloads setup file using relative file path which causing issues in case working directory is not configured when running Puush installer process. Example few browsers runs Puush installer with empty working directory and then relative path points to where browser executable is, therefore Puush installer tries to download ShareX setup file to where browser folder is and because browsers mainly inside `Program Files` folder and admin access is required to be able to save there, people receives error and unable to download ShareX.

ShareX in next version will download updates to `%USERPROFILE%\AppData\Local\Temp\ShareX` folder and in startup of ShareX this folder will be cleaned. So I decided to also use this folder to be consistent and be able to take advantage of cleanup, instead of fixing relative path to always point to where Puush installer assembly is.
